### PR TITLE
Remove EnchantSpellToItem due to no longer use it.

### DIFF
--- a/Plugins/Auctionator.lua
+++ b/Plugins/Auctionator.lua
@@ -314,9 +314,6 @@ function plugin.GetExtraText(skill, recipe)
 --
 	if recipe.tradeID == 7411 then
 		--DA.DEBUG(0,"GetExtraText: itemID= "..tostring(itemID)..", type= "..type(itemID))
-		if itemID then
-			itemID = Skillet.EnchantSpellToItem[itemID] or 0
-		end
 		if itemID == 0 then
 			--DA.DEBUG(0,"GetExtraText: recipe.name= "..tostring(recipe.name)..", recipe.spellID= "..tostring(recipe.spellID)..", recipe.scrollID= "..tostring(recipe.scrollID))
 			itemID = recipe.scrollID
@@ -457,9 +454,6 @@ function plugin.RecipeNameSuffix(skill, recipe)
 --
 	if recipe.tradeID == 7411 then
 		--DA.DEBUG(0,"RecipeNameSuffix: itemID= "..tostring(itemID)..", type= "..type(itemID))
-		if itemID then
-			itemID = Skillet.EnchantSpellToItem[itemID] or 0
-		end
 		if itemID == 0 then
 			--DA.DEBUG(0,"RecipeNameSuffix: recipe.name= "..tostring(recipe.name)..", recipe.spellID= "..tostring(recipe.spellID)..", recipe.scrollID= "..tostring(recipe.scrollID))
 			itemID = recipe.scrollID
@@ -591,9 +585,6 @@ function Skillet:AuctionatorSearch(whichOne)
 --
 -- Check for Enchanting and add the Enchant name if no item is produced.
 --
-		if recipe.tradeID == 7411 and itemID then
-			itemID = Skillet.EnchantSpellToItem[itemID] or 0
-		end
 		if itemID ~= 0 then
 			shoppingListName = GetItemInfo(itemID)
 		else

--- a/Plugins/Auctioneer.lua
+++ b/Plugins/Auctioneer.lua
@@ -177,9 +177,6 @@ function plugin.GetExtraText(skill, recipe)
 -- Check for Enchanting. Most recipes don't produce an item but
 -- we still should get reagent prices.
 --
-	if recipe.tradeID == 7411 and itemID then
-		itemID = Skillet.EnchantSpellToItem[itemID] or 0
-	end
 	if Skillet.db.profile.plugins.AUC.enabled and itemID and IsAddOnLoaded("Auc-Advanced") and AucAdvanced then
 		local itemName, itemLink = GetItemInfo(itemID)
 		local market = ( GetMarketValue(itemLink) or 0 ) * recipe.numMade
@@ -246,9 +243,6 @@ function plugin.RecipeNameSuffix(skill, recipe)
 -- Check for Enchanting. Most recipes don't produce an item but
 -- we still should get reagent prices.
 --
-	if recipe.tradeID == 7411 and itemID then
-		itemID = Skillet.EnchantSpellToItem[itemID] or 0
-	end
 	if Skillet.db.profile.plugins.AUC.enabled and itemID and IsAddOnLoaded("Auc-Advanced") and AucAdvanced then
 		local buyout = ( GetMarketValue(itemLink) or 0 ) * recipe.numMade
 		if Skillet.db.profile.plugins.AUC.reagentPrices then

--- a/Plugins/Auctipus.lua
+++ b/Plugins/Auctipus.lua
@@ -175,9 +175,6 @@ function plugin.GetExtraText(skill, recipe)
 -- Check for Enchanting. Most recipes don't produce an item but
 -- we still should get reagent prices.
 --
-	if recipe.tradeID == 7411 and itemID then
-		itemID = Skillet.EnchantSpellToItem[itemID] or 0
-	end
 	if Skillet.db.profile.plugins.APS.enabled and itemID and Auctipus and Auctipus.API and Auctipus.API.GetAuctionBuyoutRange then
 		minBuyout, maxBuyout, daysElapsed = Auctipus.API.GetAuctionBuyoutRange(itemID)
 		local buyout = ( minBuyout or 0 ) * recipe.numMade
@@ -249,9 +246,6 @@ function plugin.RecipeNameSuffix(skill, recipe)
 -- Check for Enchanting. Most recipes don't produce an item but
 -- we still should get reagent prices.
 --
-	if recipe.tradeID == 7411 and itemID then
-		itemID = Skillet.EnchantSpellToItem[itemID] or 0
-	end
 	if Skillet.db.profile.plugins.APS.enabled and itemID and Auctipus and Auctipus.API and Auctipus.API.GetAuctionBuyoutRange then
 		minBuyout, maxBuyout, daysElapsed = Auctipus.API.GetAuctionBuyoutRange(itemID)
 		local buyout = ( minBuyout or 0 ) * recipe.numMade

--- a/SkilletData.lua
+++ b/SkilletData.lua
@@ -273,32 +273,6 @@ function Skillet:ConvertIgnoreListData()
 end
 
 --
--- Enchants that produce items
---
-Skillet.EnchantSpellToItem = {
-	[14923] = 11287 , -- Lesser Magic Wand
-	[25124] = 20744 , -- Minor Wizard Oil
-	[14807] = 11288 , -- Greater Magic Wand
-	[25125] = 20745 , -- Minor Mana Oil
-	[14809] = 11289 , -- Lesser Mystic Wand
-	[14810] = 11290 , -- Greater Mystic Wand
-	[25126] = 20746 , -- Lesser Wizard Oil
-	[25127] = 20747 , -- Lesser Mana Oil
-	[15596] = 11811 , -- Smoking Heart of the Mountain
-	[25128] = 20750 , -- Wizard Oil
-	[17180] = 12655 , -- Enchanted Thorium Bar
-	[17181] = 12810 , -- Enchanted Leather
-	[25130] = 20748 , -- Brilliant Mana Oil
-	[25129] = 20749 , -- Brilliant Wizard Oil
-	[28027] = 22460 , -- Prismatic Sphere
-	[28016] = 22521 , -- Superior Mana Oil
-	[28022] = 22449 , -- Large Prismatic Shard
-	[28019] = 22522 , -- Superior Wizard Oil
-	[28028] = 22459 , -- Void Sphere
-	[42615] = 22448 , -- Small Prismatic Shard
-}
-
---
 -- ItemIDs that can be produced by multiple professions
 --
 Skillet.duplicateItemID = {


### PR DESCRIPTION
It seems like the `recipe.itemID` already referer to itemID instead of spellID for enchanting.

The `EnchantSpellToItem` convert table cause a problem that makes itemID to 0. 
Remove it to fix the bug.