### PR TITLE
Update MainFrame.lua

### DIFF
--- a/UI/MainFrame.lua
+++ b/UI/MainFrame.lua
@@ -1890,7 +1890,7 @@ function Skillet:UpdateDetailsWindow(skillIndex)
 	elseif recipe.itemID ~= 0 then
 		--DA.DEBUG(1,"UpdateDetailsWindow: texture from GetItemIcon("..tostring(recipe.itemID)..")")
 		texture = GetItemIcon(recipe.itemID)
-	elseif Skillet.db.profile.enchant_scrolls and recipe.scrollID ~= 0 then
+	elseif Skillet.db.profile.enchant_scrolls and recipe.scrollID ~= 0 and recipe.scrollID ~= nil then --for ring enchants recipe.scrollID is nil.
 		--DA.DEBUG(1,"UpdateDetailsWindow: texture from GetItemIcon("..tostring(recipe.scrollID)..")")
 		texture = GetItemIcon(recipe.scrollID)
 	else


### PR DESCRIPTION
fixed following error, occurs when clicking on a ring enchant in the enchanting profession in cata classic: 
```
Usage: local icon = C_Item.GetItemIconByID(itemInfo) [string "=[C]"]: in function `GetItemIcon'


[string "@Skillet-Classic/UI/MainFrame.lua"]:1892: in function `UpdateDetailsWindow' 
[string "@Skillet-Classic/UI/MainFrame.lua"]:975: in function `UpdateTradeSkillWindow' 
[string "@Skillet-Classic/UI/MainFrame.lua"]:2538: in function `ScrollToSkillIndex' 
[string "@Skillet-Classic/Skillet.lua"]:1603: in function `SetSelectedSkill' 
[string "@Skillet-Classic/UI/MainFrame.lua"]:2459: in function `SkillButton_OnClick'
[string "*MainFrame.xml:359_OnClick"]:2: in function <[string "*MainFrame.xml:359_OnClick"]:1>
```